### PR TITLE
Relax image prompt moderation and add validation tests

### DIFF
--- a/backend/src/services/__tests__/openAIService.integration.test.ts
+++ b/backend/src/services/__tests__/openAIService.integration.test.ts
@@ -27,17 +27,30 @@ describe('OpenAI Service Integration', () => {
   });
   
   describe('Prompt Validation', () => {
-    it('should validate prompt length', () => {
+    it('should validate prompt length', async () => {
       const shortPrompt = 'A simple scene';
-      const validation = (openAIService as any).validateImagePrompt(shortPrompt);
+      const validation = await (openAIService as any).validateImagePrompt(shortPrompt);
       expect(validation.isValid).toBe(true);
     });
-    
-    it('should reject overly long prompts', () => {
+
+    it('should reject overly long prompts', async () => {
       const longPrompt = 'A'.repeat(5000);
-      const validation = (openAIService as any).validateImagePrompt(longPrompt);
+      const validation = await (openAIService as any).validateImagePrompt(longPrompt);
       expect(validation.isValid).toBe(false);
       expect(validation.errors).toContain('Prompt exceeds maximum length of 4000 characters');
+    });
+
+    it('should allow mild content like battle scenes with blood', async () => {
+      const prompt = 'A fierce battle scene with blood on the ground';
+      const validation = await (openAIService as any).validateImagePrompt(prompt);
+      expect(validation.isValid).toBe(true);
+    });
+
+    it('should block prompts with explicit gore or nudity', async () => {
+      const prompt = 'Graphic gore and complete nudity in explicit detail';
+      const validation = await (openAIService as any).validateImagePrompt(prompt);
+      expect(validation.isValid).toBe(false);
+      expect(validation.errors.some((e: string) => e.includes('gore') || e.includes('nudity'))).toBe(true);
     });
   });
 });

--- a/backend/src/services/openAIService.ts
+++ b/backend/src/services/openAIService.ts
@@ -263,7 +263,7 @@ class OpenAIService {
       };
 
       // Validate the prompt before sending to OpenAI
-      const validation = this.validateImagePrompt(enhancedPrompt);
+      const validation = await this.validateImagePrompt(enhancedPrompt);
       if (!validation.isValid) {
         logger.warn('Image prompt validation failed:', validation.errors);
         throw new Error('Invalid image prompt: ' + validation.errors.join(', '));
@@ -328,7 +328,7 @@ class OpenAIService {
     const enhancedPrompt = this.enhanceImagePrompt(prompt, style, adventureDetails);
     
     // Validate the prompt before sending to OpenAI
-    const validation = this.validateImagePrompt(enhancedPrompt);
+    const validation = await this.validateImagePrompt(enhancedPrompt);
     if (!validation.isValid) {
       logger.warn('Image prompt validation failed:', validation.errors);
       throw new Error('Invalid image prompt: ' + validation.errors.join(', '));
@@ -355,35 +355,39 @@ class OpenAIService {
   /**
    * Validate image prompt to prevent rejections by OpenAI
    */
-  private validateImagePrompt(prompt: string): { isValid: boolean; errors: string[] } {
+  private async validateImagePrompt(prompt: string): Promise<{ isValid: boolean; errors: string[] }> {
     const errors: string[] = [];
-    
+
     // Length validation
     if (prompt.length > 4000) {
       errors.push('Prompt exceeds maximum length of 4000 characters');
     }
-    
-    // Content validation for inappropriate patterns
+
+    // Content validation for clearly inappropriate patterns
     const inappropriatePatterns = [
-      /violence/gi,
-      /blood/gi,
       /gore/gi,
       /explicit/gi,
       /nudity/gi,
       /sexual/gi
     ];
-    
+
     for (const pattern of inappropriatePatterns) {
-      if (prompt.match(pattern)) {
+      if (pattern.test(prompt)) {
         errors.push(`Prompt contains potentially inappropriate content: ${pattern}`);
       }
     }
-    
+
+    // Moderation API check for additional safety
+    const isAllowed = await this.moderateContent(prompt);
+    if (!isAllowed) {
+      errors.push('Prompt flagged by content moderation');
+    }
+
     // Check for special characters that might cause issues
     if (prompt.includes('```') || prompt.includes('"""')) {
       errors.push('Prompt contains invalid formatting characters');
     }
-    
+
     return {
       isValid: errors.length === 0,
       errors
@@ -408,7 +412,7 @@ class OpenAIService {
       const enhancedPrompt = this.buildContextualPrompt(prompt, adventureContext);
       
       // Validate the prompt before sending to OpenAI
-      const validation = this.validateImagePrompt(enhancedPrompt);
+      const validation = await this.validateImagePrompt(enhancedPrompt);
       if (!validation.isValid) {
         logger.warn('Enhanced image prompt validation failed:', validation.errors);
         throw new Error('Invalid image prompt: ' + validation.errors.join(', '));


### PR DESCRIPTION
## Summary
- Relax image prompt validation by removing mild terms and using OpenAI moderation API
- Add tests ensuring mild prompts like battle scenes pass while explicit gore/nudity is blocked

## Testing
- `npm test` *(fails: Mongoose connection errors, missing JWT config)*
- `npm test -- src/services/__tests__/openAIService.integration.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68beb3c1105c832a8964045b9193e648