### PR TITLE
Add image load fallbacks with retry

### DIFF
--- a/frontend/__tests__/TurnDisplay.test.tsx
+++ b/frontend/__tests__/TurnDisplay.test.tsx
@@ -84,11 +84,10 @@ describe('TurnDisplay Component', () => {
     expect(true).toBeTruthy();
   });
 
-  it('renders without image when image_url is empty', () => {
+  it('shows placeholder when image_url is empty', () => {
     const turnWithoutImage = { ...mockTurn, image_url: '' };
-    const { queryByTestId } = render(<TurnDisplay turn={turnWithoutImage} />);
-    
-    // Should render without throwing error
-    expect(true).toBeTruthy();
+    const { getByTestId } = render(<TurnDisplay turn={turnWithoutImage} />);
+
+    expect(getByTestId('image-placeholder')).toBeTruthy();
   });
 });

--- a/frontend/__tests__/components/game/MobileOptimizedChat.test.tsx
+++ b/frontend/__tests__/components/game/MobileOptimizedChat.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { MobileOptimizedChat } from '../../../src/components/game/MobileOptimizedChat';
+import { Turn } from '../../../src/types';
+
+describe('MobileOptimizedChat Component', () => {
+  const baseTurn: Turn = {
+    turn_id: 'test_turn_1',
+    turn_number: 1,
+    player_input: 'Look around',
+    narration: 'You find yourself in a mysterious cave filled with glowing crystals.',
+    image_prompt: 'A mysterious cave with glowing crystals',
+    image_url: 'https://example.com/cave.jpg',
+    quick_actions: [],
+    world_state_snapshot: {
+      location: 'Crystal Cave',
+      inventory: [],
+      npcs: [],
+      flags: {},
+      current_chapter: 'Chapter 1',
+    },
+    timestamp: new Date('2024-01-01'),
+    processing_metadata: {
+      ai_response_time: 1000,
+      image_generation_time: 2000,
+      tokens_used: 150,
+    },
+  };
+
+  it('shows placeholder when image_url is empty', () => {
+    const turnWithoutImage = { ...baseTurn, image_url: '' } as any;
+    const { getByTestId } = render(
+      <MobileOptimizedChat turns={[turnWithoutImage]} />
+    );
+    expect(getByTestId('image-placeholder')).toBeTruthy();
+  });
+});

--- a/frontend/src/components/game/MobileOptimizedChat.tsx
+++ b/frontend/src/components/game/MobileOptimizedChat.tsx
@@ -37,7 +37,9 @@ const TurnDisplay: React.FC<TurnDisplayProps> = ({
   onTextLongPress,
   enableHaptics = true,
 }) => {
-  
+  const [imageError, setImageError] = useState(false);
+  const [reloadKey, setReloadKey] = useState(0);
+
   const handleImagePress = async () => {
     if (enableHaptics) {
       await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
@@ -56,6 +58,11 @@ const TurnDisplay: React.FC<TurnDisplayProps> = ({
     }
   };
 
+  const handleRetry = () => {
+    setImageError(false);
+    setReloadKey((k) => k + 1);
+  };
+
   return (
     <View style={styles.turnContainer}>
       {/* Player Input */}
@@ -70,16 +77,29 @@ const TurnDisplay: React.FC<TurnDisplayProps> = ({
       {/* AI Response */}
       <View style={styles.aiResponseContainer}>
         {/* Image */}
-        {turn.image_url && (
+        {!turn.image_url || imageError ? (
+          <View style={styles.placeholderContainer} testID="image-placeholder">
+            <Text style={styles.placeholderText}>
+              {imageError ? 'Failed to load image.' : 'No image available.'}
+            </Text>
+            {imageError && (
+              <TouchableOpacity style={styles.retryButton} onPress={handleRetry}>
+                <Text style={styles.retryButtonText}>Retry</Text>
+              </TouchableOpacity>
+            )}
+          </View>
+        ) : (
           <TouchableOpacity
             style={styles.imageContainer}
             onPress={handleImagePress}
             activeOpacity={0.8}
           >
             <Image
+              key={reloadKey}
               source={{ uri: turn.image_url }}
               style={styles.turnImage}
               resizeMode="cover"
+              onError={() => setImageError(true)}
             />
             <View style={styles.imageOverlay}>
               <Ionicons name="expand" size={20} color="white" />
@@ -274,6 +294,31 @@ const styles = StyleSheet.create({
     width: width * 0.8,
     height: (width * 0.8) * 0.6,
     borderRadius: 12,
+  },
+  placeholderContainer: {
+    width: width * 0.8,
+    height: (width * 0.8) * 0.6,
+    backgroundColor: '#404040',
+    borderRadius: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 12,
+  },
+  placeholderText: {
+    color: '#9ca3af',
+    fontSize: 14,
+    marginBottom: 8,
+    textAlign: 'center',
+  },
+  retryButton: {
+    backgroundColor: '#6b46c1',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 4,
+  },
+  retryButtonText: {
+    color: '#fff',
+    fontSize: 12,
   },
   imageOverlay: {
     position: 'absolute',

--- a/frontend/src/components/game/TurnDisplay.tsx
+++ b/frontend/src/components/game/TurnDisplay.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { View, Text, Image, StyleSheet, TouchableOpacity, Dimensions } from 'react-native';
 import { Turn } from '../../types';
 
@@ -10,11 +10,52 @@ interface TurnDisplayProps {
 
 const { width } = Dimensions.get('window');
 
-export const TurnDisplay: React.FC<TurnDisplayProps> = ({ 
-  turn, 
-  onImagePress, 
-  isLatest = false 
+export const TurnDisplay: React.FC<TurnDisplayProps> = ({
+  turn,
+  onImagePress,
+  isLatest = false
 }) => {
+  const [imageError, setImageError] = useState(false);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  const handleRetry = () => {
+    setImageError(false);
+    setReloadKey((k) => k + 1);
+  };
+
+  const renderImage = () => {
+    if (!turn.image_url || imageError) {
+      return (
+        <View style={styles.placeholderContainer} testID="image-placeholder">
+          <Text style={styles.placeholderText}>
+            {imageError ? 'Failed to load image.' : 'No image available.'}
+          </Text>
+          {imageError && (
+            <TouchableOpacity style={styles.retryButton} onPress={handleRetry}>
+              <Text style={styles.retryButtonText}>Retry</Text>
+            </TouchableOpacity>
+          )}
+        </View>
+      );
+    }
+
+    return (
+      <TouchableOpacity
+        style={styles.imageContainer}
+        onPress={onImagePress}
+        activeOpacity={0.8}
+      >
+        <Image
+          key={reloadKey}
+          source={{ uri: turn.image_url }}
+          style={styles.image}
+          resizeMode="cover"
+          onError={() => setImageError(true)}
+        />
+      </TouchableOpacity>
+    );
+  };
+
   return (
     <View style={[styles.container, isLatest && styles.latestTurn]}>
       {/* Player Input */}
@@ -31,19 +72,7 @@ export const TurnDisplay: React.FC<TurnDisplayProps> = ({
       </View>
       
       {/* Image */}
-      {turn.image_url && (
-        <TouchableOpacity 
-          style={styles.imageContainer} 
-          onPress={onImagePress}
-          activeOpacity={0.8}
-        >
-          <Image 
-            source={{ uri: turn.image_url }} 
-            style={styles.image}
-            resizeMode="cover"
-          />
-        </TouchableOpacity>
-      )}
+      {renderImage()}
       
       {/* Quick Actions */}
       {turn.quick_actions && turn.quick_actions.length > 0 && (
@@ -121,6 +150,30 @@ const styles = StyleSheet.create({
     width: width - 64,
     height: (width - 64) * 0.75,
     backgroundColor: '#404040',
+  },
+  placeholderContainer: {
+    width: width - 64,
+    height: (width - 64) * 0.75,
+    backgroundColor: '#404040',
+    borderRadius: 8,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 12,
+  },
+  placeholderText: {
+    color: '#9ca3af',
+    fontSize: 14,
+    marginBottom: 8,
+  },
+  retryButton: {
+    backgroundColor: '#6b46c1',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 4,
+  },
+  retryButtonText: {
+    color: '#fff',
+    fontSize: 12,
   },
   quickActionsContainer: {
     backgroundColor: '#1a1a1a',

--- a/frontend/src/components/launcher/RecentGames.tsx
+++ b/frontend/src/components/launcher/RecentGames.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   View,
   Text,
@@ -42,10 +42,18 @@ const GameCard: React.FC<GameCardProps> = ({ game, onPress }) => {
   };
   
   const genreInfo = getGenreInfo();
-  
+
   const handlePress = async () => {
     await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
     onPress();
+  };
+
+  const [imageError, setImageError] = useState(false);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  const handleRetry = () => {
+    setImageError(false);
+    setReloadKey((k) => k + 1);
   };
   
   return (
@@ -56,16 +64,23 @@ const GameCard: React.FC<GameCardProps> = ({ game, onPress }) => {
     >
       {/* Game Image */}
       <View style={styles.imageContainer}>
-        {lastTurn?.image_url ? (
+        {!lastTurn?.image_url || imageError ? (
+          <View style={styles.placeholderImage} testID="image-placeholder">
+            <Ionicons name={genreInfo.icon as any} size={40} color={genreInfo.color} />
+            {imageError && (
+              <TouchableOpacity style={styles.retryButton} onPress={handleRetry}>
+                <Ionicons name="refresh" size={20} color="white" />
+              </TouchableOpacity>
+            )}
+          </View>
+        ) : (
           <Image
+            key={reloadKey}
             source={{ uri: lastTurn.image_url }}
             style={styles.gameImage}
             resizeMode="cover"
+            onError={() => setImageError(true)}
           />
-        ) : (
-          <View style={styles.placeholderImage}>
-            <Ionicons name={genreInfo.icon as any} size={40} color={genreInfo.color} />
-          </View>
         )}
         
         {/* Genre Badge */}
@@ -210,6 +225,12 @@ const styles = StyleSheet.create({
     backgroundColor: 'rgba(139, 92, 246, 0.1)',
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  retryButton: {
+    marginTop: 8,
+    backgroundColor: '#6b46c1',
+    padding: 6,
+    borderRadius: 16,
   },
   genreBadge: {
     position: 'absolute',


### PR DESCRIPTION
## Summary
- Show placeholder and retry button when turn images are missing or fail to load
- Add same placeholder handling to mobile chat and recent games list
- Test that placeholders render when `image_url` is absent

## Testing
- `npm test` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68beb3d4d9e4832abf9949560d4eea57