### PR TITLE
Fix Create Adventure button gating

### DIFF
--- a/frontend/src/screens/CustomAdventureScreen.tsx
+++ b/frontend/src/screens/CustomAdventureScreen.tsx
@@ -311,11 +311,11 @@ export const CustomAdventureScreen: React.FC = () => {
           style={[
             styles.navButton,
             styles.primaryButton,
-            (!canGoNext && currentStep < WIZARD_STEPS.length - 1) && styles.disabledButton,
+            !canGoNext && styles.disabledButton,
             isCreatingGame && styles.loadingButton,
           ]}
           onPress={handleNext}
-          disabled={(!canGoNext && currentStep < WIZARD_STEPS.length - 1) || isCreatingGame}
+          disabled={!canGoNext || isCreatingGame}
         >
           {isCreatingGame ? (
             <>

--- a/frontend/src/store/customAdventureSlice.ts
+++ b/frontend/src/store/customAdventureSlice.ts
@@ -453,7 +453,7 @@ export const selectCanNavigateNext = (state: { customAdventure: CustomAdventureS
   const { currentStep, maxSteps, currentAdventure } = state.customAdventure;
   
   if (!currentAdventure) return false;
-  if (currentStep >= maxSteps - 1) return false;
+  if (currentStep > maxSteps - 1) return false;
   
   // Check if current step is complete
   switch (currentStep) {


### PR DESCRIPTION
## Summary
- allow final step of custom adventure wizard to count as complete
- disable navigation button based solely on step validity

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68bebfa16e9c832ab9d7b407988c65c9