### PR TITLE
Add prompt-based adventure creation

### DIFF
--- a/backend/src/services/gameEngine.ts
+++ b/backend/src/services/gameEngine.ts
@@ -15,7 +15,8 @@ import {
   SavedGamesResponse,
   CustomAdventureRequest,
   CustomAdventureResponse,
-  AdventureDetails 
+  PromptAdventureRequest,
+  AdventureDetails
 } from '../../../shared/types';
 import { 
   validatePlayerInput, 
@@ -275,6 +276,19 @@ class GameEngine {
       }
       throw new CustomError('Failed to create custom adventure', HTTP_STATUS.INTERNAL_SERVER_ERROR);
     }
+  }
+
+  async createCustomGameFromPrompt(request: PromptAdventureRequest, userId: string): Promise<CustomAdventureResponse> {
+    const adventureDetails = await openAIService.generateAdventureFromPrompt(request.prompt);
+    const customRequest: CustomAdventureRequest = {
+      genre: 'custom',
+      style_preference: request.style_preference || 'detailed',
+      image_style: request.image_style || 'fantasy_art',
+      safety_filter: request.safety_filter,
+      content_rating: request.content_rating,
+      adventure_details: adventureDetails
+    };
+    return this.createCustomGame(customRequest, userId);
   }
 
   async processTurn(request: TurnRequest, userId: string): Promise<TurnResponse> {

--- a/frontend/src/navigation/AppNavigator.tsx
+++ b/frontend/src/navigation/AppNavigator.tsx
@@ -6,6 +6,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { GameScreen } from '../screens/GameScreen';
 import { NewGameScreen } from '../screens/NewGameScreen';
 import { CustomAdventureScreen } from '../screens/CustomAdventureScreen';
+import { PromptAdventureScreen } from '../screens/PromptAdventureScreen';
 import { GameLauncher } from '../screens/GameLauncher';
 import { SplashScreen } from '../screens/SplashScreen';
 import { OnboardingFlow } from '../screens/OnboardingFlow';
@@ -27,6 +28,7 @@ const linking = {
               Launcher: 'launcher',
               NewGame: 'new-game/:genre?',
               CustomAdventure: 'custom-adventure',
+              PromptAdventure: 'prompt-adventure',
               Game: 'game/:sessionId',
             },
           },
@@ -76,6 +78,14 @@ const GameStackNavigator: React.FC = () => {
         component={CustomAdventureScreen}
         options={{
           title: 'Create Custom Adventure',
+          headerTitleAlign: 'center',
+        }}
+      />
+      <Stack.Screen
+        name="PromptAdventure"
+        component={PromptAdventureScreen}
+        options={{
+          title: 'Prompt Adventure',
           headerTitleAlign: 'center',
         }}
       />

--- a/frontend/src/screens/NewGameScreen.tsx
+++ b/frontend/src/screens/NewGameScreen.tsx
@@ -36,6 +36,13 @@ const gameTypes = [
     icon: 'library',
     description: 'Start from a community-created adventure template',
     color: '#f59e0b'
+  },
+  {
+    key: 'prompt',
+    label: 'Prompt Adventure',
+    icon: 'create',
+    description: 'Generate an adventure from your own prompt',
+    color: '#3b82f6'
   }
 ];
 
@@ -64,7 +71,7 @@ export const NewGameScreen: React.FC = () => {
   const [startNewGame, { isLoading }] = useStartNewGameMutation();
   const { data: templatesData } = useGetAdventureTemplatesQuery({ limit: 10 });
 
-  const [gameType, setGameType] = useState<'preset' | 'custom' | 'template'>('preset');
+  const [gameType, setGameType] = useState<'preset' | 'custom' | 'template' | 'prompt'>('preset');
   const [selectedGenre, setSelectedGenre] = useState<string>('fantasy');
   const [selectedImageStyle, setSelectedImageStyle] = useState<string>('fantasy_art');
   const [selectedStylePreference, setSelectedStylePreference] = useState<string>('detailed');
@@ -74,6 +81,11 @@ export const NewGameScreen: React.FC = () => {
     if (gameType === 'custom') {
       // Navigate to custom adventure creation wizard
       (navigation as any).navigate('CustomAdventure');
+      return;
+    }
+
+    if (gameType === 'prompt') {
+      (navigation as any).navigate('PromptAdventure');
       return;
     }
 

--- a/frontend/src/screens/PromptAdventureScreen.tsx
+++ b/frontend/src/screens/PromptAdventureScreen.tsx
@@ -1,0 +1,156 @@
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  StyleSheet,
+  SafeAreaView,
+  Alert,
+} from 'react-native';
+import { Picker } from '@react-native-picker/picker';
+import { useNavigation } from '@react-navigation/native';
+import { useAppDispatch, useAppSelector } from '../utils/hooks';
+import { useCreatePromptGameMutation } from '../services/gameApi';
+import { setCurrentSession } from '../store/gameSlice';
+
+export const PromptAdventureScreen: React.FC = () => {
+  const navigation = useNavigation();
+  const dispatch = useAppDispatch();
+  const settings = useAppSelector(state => state.settings);
+
+  const [prompt, setPrompt] = useState('');
+  const [stylePreference, setStylePreference] = useState<'detailed' | 'concise'>('detailed');
+  const [imageStyle, setImageStyle] = useState<'fantasy_art' | 'comic_book' | 'painterly'>('fantasy_art');
+  const [createPromptGame, { isLoading }] = useCreatePromptGameMutation();
+
+  const handleCreate = async () => {
+    if (!prompt.trim()) {
+      Alert.alert('Prompt Required', 'Please enter a prompt to continue.');
+      return;
+    }
+
+    try {
+      const result = await createPromptGame({
+        prompt,
+        style_preference: stylePreference,
+        image_style: imageStyle,
+        safety_filter: settings.safetyFilter,
+        content_rating: settings.contentRating,
+      }).unwrap();
+
+      dispatch(setCurrentSession({
+        session_id: result.session_id,
+        world_state: result.world_state,
+        turn_history: [{
+          turn_id: 'prologue',
+          turn_number: 0,
+          player_input: 'START',
+          narration: result.prologue.narration,
+          image_prompt: '',
+          image_url: result.prologue.image_url,
+          quick_actions: result.prologue.quick_actions,
+          world_state_snapshot: result.world_state,
+          timestamp: new Date(),
+          processing_metadata: {
+            ai_response_time: 0,
+            image_generation_time: 0,
+            tokens_used: 0,
+          },
+        }],
+        quick_actions: result.prologue.quick_actions,
+      }));
+
+      (navigation as any).navigate('Game', { sessionId: result.session_id });
+    } catch (error: any) {
+      console.error('Failed to create prompt adventure:', error);
+      Alert.alert('Error', error.data?.message || 'Failed to create adventure');
+    }
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <Text style={styles.label}>Adventure Prompt</Text>
+      <TextInput
+        style={styles.input}
+        multiline
+        placeholder="Describe your adventure..."
+        placeholderTextColor="#9ca3af"
+        value={prompt}
+        onChangeText={setPrompt}
+      />
+
+      <Text style={styles.label}>Narrative Style</Text>
+      <Picker
+        selectedValue={stylePreference}
+        onValueChange={itemValue => setStylePreference(itemValue as any)}
+        style={styles.picker}
+      >
+        <Picker.Item label="Detailed" value="detailed" />
+        <Picker.Item label="Concise" value="concise" />
+      </Picker>
+
+      <Text style={styles.label}>Image Style</Text>
+      <Picker
+        selectedValue={imageStyle}
+        onValueChange={itemValue => setImageStyle(itemValue as any)}
+        style={styles.picker}
+      >
+        <Picker.Item label="Fantasy Art" value="fantasy_art" />
+        <Picker.Item label="Comic Book" value="comic_book" />
+        <Picker.Item label="Painterly" value="painterly" />
+      </Picker>
+
+      <TouchableOpacity
+        style={[styles.button, isLoading && styles.buttonDisabled]}
+        onPress={handleCreate}
+        disabled={isLoading}
+      >
+        <Text style={styles.buttonText}>{isLoading ? 'Creating...' : 'Start Adventure'}</Text>
+      </TouchableOpacity>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#1f2937',
+    padding: 16,
+  },
+  label: {
+    color: '#f3f4f6',
+    fontSize: 16,
+    marginBottom: 8,
+    marginTop: 16,
+  },
+  input: {
+    backgroundColor: '#374151',
+    color: '#f3f4f6',
+    padding: 12,
+    borderRadius: 8,
+    minHeight: 80,
+    textAlignVertical: 'top',
+  },
+  picker: {
+    backgroundColor: '#374151',
+    color: '#f3f4f6',
+  },
+  button: {
+    backgroundColor: '#3b82f6',
+    padding: 16,
+    borderRadius: 8,
+    alignItems: 'center',
+    marginTop: 24,
+  },
+  buttonDisabled: {
+    opacity: 0.6,
+  },
+  buttonText: {
+    color: '#ffffff',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});
+
+export default PromptAdventureScreen;

--- a/frontend/src/services/gameApi.ts
+++ b/frontend/src/services/gameApi.ts
@@ -10,6 +10,7 @@ import {
   GameSession,
   CustomAdventureRequest,
   CustomAdventureResponse,
+  PromptAdventureRequest,
   AdventureDetails,
   AdventureValidationResult,
   AdventureSuggestion,
@@ -177,6 +178,15 @@ export const gameApi = createApi({
       invalidatesTags: ['Sessions', 'Adventure'],
     }),
 
+    createPromptGame: builder.mutation<CustomAdventureResponse, PromptAdventureRequest>({
+      query: (body) => ({
+        url: '/new-prompt-game',
+        method: 'POST',
+        body,
+      }),
+      invalidatesTags: ['Sessions', 'Adventure'],
+    }),
+
     validateAdventure: builder.mutation<AdventureValidationResult, { adventure_details: AdventureDetails }>({
       query: (body) => ({
         url: '/validate-adventure',
@@ -250,6 +260,7 @@ export const {
   useHealthCheckQuery,
   // Custom Adventure hooks
   useCreateCustomGameMutation,
+  useCreatePromptGameMutation,
   useValidateAdventureMutation,
   useGetAdventureSuggestionsMutation,
   useGetUserAdventuresQuery,

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -1,6 +1,7 @@
 export const API_ENDPOINTS = {
   NEW_GAME: '/api/new-game',
   NEW_CUSTOM_GAME: '/api/new-custom-game',
+  NEW_PROMPT_GAME: '/api/new-prompt-game',
   TURN: '/api/turn',
   LOAD_GAME: '/api/game',
   SAVE_GAME: '/api/save-game',

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -75,6 +75,16 @@ export interface NewGameResponse {
   world_state: WorldState;
 }
 
+export interface PromptAdventureRequest {
+  prompt: string;
+  style_preference?: 'detailed' | 'concise';
+  image_style?: 'fantasy_art' | 'comic_book' | 'painterly';
+  safety_filter?: boolean;
+  content_rating?: 'PG-13' | 'R';
+}
+
+export type PromptAdventureResponse = CustomAdventureResponse;
+
 export interface TurnRequest {
   session_id: string;
   player_input: string;


### PR DESCRIPTION
## Summary
- support PromptAdventureRequest type and API endpoint for prompt-based adventures
- generate adventure details from free-form prompts via OpenAI service
- add frontend screen and navigation for creating prompt adventures

## Testing
- `npm test` (backend) *(fails: Can't call `openUri()` on an active connection)*
- `npm test` (frontend) *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bec5f1ab58832aa52e18152be4e262