### PR TITLE
Disable backend-dev auto restart

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -33,7 +33,7 @@ services:
       context: ./backend
       dockerfile: Dockerfile.dev
     container_name: dungeon-ai-backend-dev
-    restart: unless-stopped
+    restart: "no"
     environment:
       - NODE_ENV=development
       - MONGODB_URI=mongodb://mongodb:27017/dungeon-ai


### PR DESCRIPTION
## Summary
- prevent backend-dev container from automatically restarting in docker-compose.dev.yml

## Testing
- `npm test` *(fails: Missing script: "test")*
- `docker compose -f docker-compose.dev.yml config` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68bed63d55ec832aaa980a7cdb9ad607