### PR TITLE
Use named volume for backend dev node modules

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -51,7 +51,7 @@ services:
       - dungeon-ai-dev-network
     volumes:
       - ./backend:/app
-      - /app/node_modules
+      - backend_dev_node_modules:/app/node_modules
       - backend_dev_logs:/app/logs
 
 networks:
@@ -64,4 +64,6 @@ volumes:
   redis_dev_data:
     driver: local
   backend_dev_logs:
+    driver: local
+  backend_dev_node_modules:
     driver: local


### PR DESCRIPTION
## Summary
- switch backend-dev service to use a named volume for node modules
- define `backend_dev_node_modules` volume in docker-compose.dev

## Testing
- `docker compose -f docker-compose.dev.yml build backend-dev` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68bed6357e44832a887e345c7a54a6a0