### PR TITLE
Validate required environment variables at startup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# Environment variables for local development
+# Copy this file to `.env` and replace the placeholder values.
+
+# MongoDB connection string (required)
+MONGODB_URI=mongodb://localhost:27017/dungeon-ai
+
+# Redis connection string (required)
+REDIS_URL=redis://localhost:6379
+
+# Secret key for signing JWTs (required)
+JWT_SECRET=your_super_secret_jwt_key_here
+
+# OpenAI API key for content generation (required)
+OPENAI_API_KEY=your_openai_api_key_here
+
+# Port for the backend server (optional)
+PORT=3001
+
+# Comma-separated list of allowed origins (optional)
+ALLOWED_ORIGINS=http://localhost:3000
+

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -20,6 +20,14 @@ import { authMiddleware } from './middleware/auth';
 import gameRoutes from './routes/game';
 import authRoutes from './routes/auth';
 
+// Ensure critical environment variables are defined
+const requiredEnvVars = ['MONGODB_URI', 'REDIS_URL', 'JWT_SECRET', 'OPENAI_API_KEY'];
+const missingEnvVars = requiredEnvVars.filter((name) => !process.env[name]);
+if (missingEnvVars.length > 0) {
+  missingEnvVars.forEach((name) => logger.error(`Missing environment variable: ${name}`));
+  process.exit(1);
+}
+
 // Remove duplicate dotenv.config() since it's now at the top
 const app = express();
 const PORT = process.env.PORT || 3001;


### PR DESCRIPTION
## Summary
- Ensure the server exits with an error if critical env vars (MONGODB_URI, REDIS_URL, JWT_SECRET, OPENAI_API_KEY) are missing
- Add `.env.example` to document required configuration for developers

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `MONGODB_URI=mongodb://localhost:27017/test REDIS_URL=redis://localhost:6379 JWT_SECRET=testsecret OPENAI_API_KEY=key npm test` *(fails: test suite errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bed63a0224832abfe88e6a18645f7f