### PR TITLE
fix: replace Slider with @react-native-community/slider

### DIFF
--- a/frontend/__tests__/components/game/AudioPlayer.test.tsx
+++ b/frontend/__tests__/components/game/AudioPlayer.test.tsx
@@ -4,6 +4,8 @@ import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import AudioPlayer from '../../../src/components/game/AudioPlayer';
 
+jest.mock('@react-native-community/slider', () => 'Slider');
+
 // Mock expo-av
 jest.mock('expo-av', () => ({
   Audio: {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "@expo/vector-icons": "^14.1.0",
         "@react-native-async-storage/async-storage": "2.1.2",
         "@react-native-community/netinfo": "^11.4.1",
+        "@react-native-community/slider": "^4.4.3",
         "@react-native-picker/picker": "^2.11.1",
         "@react-navigation/bottom-tabs": "^7.3.10",
         "@react-navigation/native": "^7.1.6",
@@ -3822,6 +3823,12 @@
       "peerDependencies": {
         "react-native": ">=0.59"
       }
+    },
+    "node_modules/@react-native-community/slider": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/@react-native-community/slider/-/slider-4.5.7.tgz",
+      "integrity": "sha512-WMDDZjNF2Bd8M8TrSqKf5xhM9ikdfCHtSPur64Ow3bB/OVrKufUQZ59NmYdNZNeGPvcHHTsafuYTY8zfZfbchQ==",
+      "license": "MIT"
     },
     "node_modules/@react-native-picker/picker": {
       "version": "2.11.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "@expo/vector-icons": "^14.1.0",
     "@react-native-async-storage/async-storage": "2.1.2",
     "@react-native-community/netinfo": "^11.4.1",
+    "@react-native-community/slider": "^4.4.3",
     "@react-native-picker/picker": "^2.11.1",
     "@react-navigation/bottom-tabs": "^7.3.10",
     "@react-navigation/native": "^7.1.6",

--- a/frontend/src/components/game/AudioPlayer.tsx
+++ b/frontend/src/components/game/AudioPlayer.tsx
@@ -4,10 +4,10 @@ import {
   Text,
   TouchableOpacity,
   StyleSheet,
-  Slider,
   Alert,
   ActivityIndicator,
 } from 'react-native';
+import Slider from '@react-native-community/slider';
 import { Ionicons } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
 import { Audio } from 'expo-av'; // Import expo-av
@@ -238,7 +238,6 @@ const AudioPlayer: React.FC<AudioPlayerProps> = ({
                 onSlidingComplete={handleSeek}
                 minimumTrackTintColor="#6b46c1"
                 maximumTrackTintColor="#404040"
-                thumbStyle={styles.thumb}
               />
               <Text style={styles.timeText}>{formatTime(duration)}</Text>
             </View>
@@ -273,7 +272,6 @@ const AudioPlayer: React.FC<AudioPlayerProps> = ({
                 onSlidingComplete={handleSpeedChange}
                 minimumTrackTintColor="#6b46c1"
                 maximumTrackTintColor="#404040"
-                thumbStyle={styles.thumb}
               />
               <Text style={styles.speedText}>{playbackSpeed}x</Text>
             </View>
@@ -392,12 +390,6 @@ const styles = StyleSheet.create({
     fontSize: 14,
     width: 40,
     textAlign: 'right',
-  },
-  thumb: {
-    backgroundColor: '#6b46c1',
-    width: 20,
-    height: 20,
-    borderRadius: 10,
   },
 });
 


### PR DESCRIPTION
## Summary
- use `@react-native-community/slider` instead of deprecated `Slider` from react-native
- drop unsupported `thumbStyle` prop and clean up styles
- mock community Slider in tests and add dependency

## Testing
- `npm test` *(fails: Cannot use import statement outside a module in expo)*

------
https://chatgpt.com/codex/tasks/task_e_68bf4256c3cc832aac7ade6ecdd0b13c