### PR TITLE
Fix audio time formatting and add tests

### DIFF
--- a/frontend/__tests__/components/game/AudioPlayer.test.tsx
+++ b/frontend/__tests__/components/game/AudioPlayer.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
-import AudioPlayer from '../../../src/components/game/AudioPlayer';
+import AudioPlayer, { formatTime } from '../../../src/components/game/AudioPlayer';
 
 // Mock expo-av
 jest.mock('expo-av', () => ({
@@ -120,5 +120,15 @@ describe('AudioPlayer', () => {
         quality: 'standard',
       }
     });
+  });
+});
+
+describe('formatTime', () => {
+  it('formats durations below one minute', () => {
+    expect(formatTime(5)).toBe('0:05');
+  });
+
+  it('formats durations above one minute', () => {
+    expect(formatTime(65)).toBe('1:05');
   });
 });

--- a/frontend/src/components/game/AudioPlayer.tsx
+++ b/frontend/src/components/game/AudioPlayer.tsx
@@ -15,6 +15,12 @@ import { useAppSelector, useAppDispatch } from '../../utils/hooks';
 import { updateAudioSettings } from '../../store/settingsSlice';
 import { useGenerateSpeechMutation } from '../../services/gameApi';
 
+export const formatTime = (seconds: number) => {
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60);
+  return `${mins}:${secs < 10 ? '0' : ''}${secs}`;
+};
+
 interface AudioPlayerProps {
   sessionId: string;
   narrationText: string;
@@ -182,12 +188,6 @@ const AudioPlayer: React.FC<AudioPlayerProps> = ({
 
   const handleSpeedChange = (speed: number) => {
     dispatch(updateAudioSettings({ playbackSpeed: speed }));
-  };
-
-  const formatTime = (seconds: number) => {
-    const mins = Math.floor(seconds);
-    const secs = Math.floor((seconds - mins) * 60);
-    return `${mins}:${secs < 10 ? '0' : ''}${secs}`;
   };
 
   if (!isAudioEnabled) {


### PR DESCRIPTION
## Summary
- fix AudioPlayer time formatting to correctly compute minutes and seconds
- test formatTime for durations under and over one minute

## Testing
- `npm test` *(fails: Cannot use import statement outside a module)*
- `npx jest __tests__/components/game/AudioPlayer.test.tsx` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68bf425a8ff4832aaad3ecdd36c48676