### PR TITLE
Use boxShadow in frontend components

### DIFF
--- a/frontend/src/components/game/ImageDisplay.tsx
+++ b/frontend/src/components/game/ImageDisplay.tsx
@@ -128,10 +128,7 @@ const styles = StyleSheet.create({
     overflow: 'hidden',
     marginBottom: 12,
     elevation: 3,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.25,
-    shadowRadius: 3.84,
+    boxShadow: '0px 2px 3.84px rgba(0, 0, 0, 0.25)',
     position: 'relative',
   },
   image: {

--- a/frontend/src/components/launcher/QuickActions.tsx
+++ b/frontend/src/components/launcher/QuickActions.tsx
@@ -153,10 +153,7 @@ const styles = StyleSheet.create({
     borderRadius: 16,
     marginBottom: 16,
     elevation: 4,
-    shadowColor: '#8b5cf6',
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.3,
-    shadowRadius: 8,
+    boxShadow: '0px 4px 8px rgba(139, 92, 246, 0.3)',
   },
   primaryGradient: {
     padding: 24,

--- a/frontend/src/screens/GameLibrary.tsx
+++ b/frontend/src/screens/GameLibrary.tsx
@@ -294,10 +294,7 @@ const styles = StyleSheet.create({
     borderRadius: 12,
     overflow: 'hidden',
     elevation: 3,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.25,
-    shadowRadius: 3.84,
+    boxShadow: '0px 2px 3.84px rgba(0, 0, 0, 0.25)',
   },
   cardGradient: {
     flexDirection: 'row',


### PR DESCRIPTION
## Summary
- replace shadowColor/shadowOffset/shadowOpacity/shadowRadius with boxShadow for GameLibrary, QuickActions, and ImageDisplay components

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68bf4395bb30832a87675fea42676419