### PR TITLE
Disable native driver animations on web

### DIFF
--- a/frontend/src/components/game/SwipeableInputBox.tsx
+++ b/frontend/src/components/game/SwipeableInputBox.tsx
@@ -10,6 +10,7 @@ import {
   Animated,
   PanResponder,
   Dimensions,
+  Platform,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
@@ -97,14 +98,14 @@ export const SwipeableInputBox: React.FC<SwipeableInputBoxProps> = ({
       Animated.parallel([
         Animated.spring(translateX, {
           toValue: 0,
-          useNativeDriver: true,
+          useNativeDriver: Platform.OS !== 'web',
           tension: 100,
           friction: 8,
         }),
         Animated.timing(swipeOpacity, {
           toValue: 0,
           duration: 200,
-          useNativeDriver: true,
+          useNativeDriver: Platform.OS !== 'web',
         }),
       ]).start();
       

--- a/frontend/src/screens/SplashScreen.tsx
+++ b/frontend/src/screens/SplashScreen.tsx
@@ -5,6 +5,7 @@ import {
   StyleSheet,
   Animated,
   ActivityIndicator,
+  Platform,
 } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useNavigation } from '@react-navigation/native';
@@ -59,20 +60,20 @@ export const SplashScreen: React.FC = () => {
   };
   
   const startAnimations = () => {
-    Animated.parallel([
-      Animated.timing(fadeAnim, {
-        toValue: 1,
-        duration: 800,
-        useNativeDriver: true,
-      }),
-      Animated.spring(scaleAnim, {
-        toValue: 1,
-        tension: 50,
-        friction: 8,
-        useNativeDriver: true,
-      }),
-    ]).start();
-  };
+      Animated.parallel([
+        Animated.timing(fadeAnim, {
+          toValue: 1,
+          duration: 800,
+        useNativeDriver: Platform.OS !== 'web',
+        }),
+        Animated.spring(scaleAnim, {
+          toValue: 1,
+          tension: 50,
+          friction: 8,
+        useNativeDriver: Platform.OS !== 'web',
+        }),
+      ]).start();
+    };
   
   const preloadAppData = async () => {
     try {


### PR DESCRIPTION
## Summary
- Add Platform import and conditionally disable `useNativeDriver` for web animations

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68bf46944454832abfff65f00ddf657c