### PR TITLE
Allow local frontend origin

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -14,7 +14,7 @@ PORT=3001
 NODE_ENV=development
 
 # CORS
-ALLOWED_ORIGINS=http://localhost:3000,http://localhost:19006
+ALLOWED_ORIGINS=http://localhost:3000,http://localhost:8082,http://localhost:19006
 
 # Rate Limiting
 RATE_LIMIT_WINDOW_MS=60000

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -68,7 +68,11 @@ app.use(helmet({
 }));
 
 app.use(cors({
-  origin: process.env.ALLOWED_ORIGINS?.split(',') || ['http://localhost:3000'],
+  origin:
+    process.env.ALLOWED_ORIGINS?.split(',') || [
+      'http://localhost:3000',
+      'http://localhost:8082',
+    ],
   credentials: true,
 }));
 


### PR DESCRIPTION
## Summary
- include http://localhost:8082 in default CORS origins
- document frontend URL in ALLOWED_ORIGINS example

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf468cc8e4832ab59220097c73e6f5