### PR TITLE
fix: replace invalid Ionicons castle icon

### DIFF
--- a/frontend/src/components/launcher/RecentGames.tsx
+++ b/frontend/src/components/launcher/RecentGames.tsx
@@ -35,7 +35,7 @@ const GameCard: React.FC<GameCardProps> = ({ game, onPress }) => {
   const getGenreInfo = () => {
     // You could expand this to detect genre from world state
     return {
-      icon: 'castle',
+      icon: 'home',
       color: '#8b5cf6',
       label: 'Adventure'
     };

--- a/frontend/src/screens/OnboardingFlow.tsx
+++ b/frontend/src/screens/OnboardingFlow.tsx
@@ -39,7 +39,7 @@ const WelcomeSlide: React.FC<OnboardingSlideProps> = ({ onNext, onSkip }) => {
         Your choices shape the story!
       </Text>
       <View style={styles.iconContainer}>
-        <Ionicons name="castle" size={80} color="#8b5cf6" />
+        <Ionicons name="home" size={80} color="#8b5cf6" />
       </View>
       <View style={styles.buttonContainer}>
         <TouchableOpacity style={styles.primaryButton} onPress={onNext}>


### PR DESCRIPTION
## Summary
- replace nonexistent Ionicons `castle` icon with `home`
- use `home` icon for recent games genre badge

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68bf468f28bc832a9d2ae9cfc73830c3