### PR TITLE
Handle initialization errors in frontend App

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -1,6 +1,7 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { StatusBar } from 'expo-status-bar';
 import { Provider } from 'react-redux';
+import { View, Text, Button, ActivityIndicator, StyleSheet } from 'react-native';
 import * as Notifications from 'expo-notifications';
 import NetInfo from '@react-native-community/netinfo';
 import { store } from './src/store';
@@ -8,7 +9,7 @@ import { AppNavigator } from './src/navigation/AppNavigator';
 import { useCreateAnonymousSessionMutation } from './src/services/gameApi';
 import { useAppDispatch } from './src/utils/hooks';
 import { setCredentials } from './src/store/authSlice';
-import { setOnlineStatus } from './src/store/offlineSlice';
+import { setOnlineStatus, setOfflineMode } from './src/store/offlineSlice';
 
 // Configure notifications
 Notifications.setNotificationHandler({
@@ -22,11 +23,12 @@ Notifications.setNotificationHandler({
 const AppContent: React.FC = () => {
   const dispatch = useAppDispatch();
   const [createAnonymousSession] = useCreateAnonymousSessionMutation();
+  const [initError, setInitError] = useState<string | null>(null);
+  const [isInitializing, setIsInitializing] = useState(true);
 
   useEffect(() => {
-    // Initialize app
     initializeApp();
-    
+
     // Set up network monitoring
     const unsubscribe = NetInfo.addEventListener(state => {
       dispatch(setOnlineStatus(state.isConnected ?? false));
@@ -38,20 +40,48 @@ const AppContent: React.FC = () => {
   }, [dispatch]);
 
   const initializeApp = async () => {
+    setIsInitializing(true);
+    setInitError(null);
     try {
-      // Create anonymous session on app start
       const result = await createAnonymousSession().unwrap();
       dispatch(setCredentials({
         token: result.token,
         user: result.user,
       }));
-      
-      // Request notification permissions
+
       await Notifications.requestPermissionsAsync();
     } catch (error) {
       console.error('Failed to initialize app:', error);
+      setInitError('Failed to initialize app.');
+    } finally {
+      setIsInitializing(false);
     }
   };
+
+  const handleOfflineMode = () => {
+    dispatch(setOnlineStatus(false));
+    dispatch(setOfflineMode(true));
+    setInitError(null);
+  };
+
+  if (isInitializing) {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator size="large" color="#ffffff" />
+      </View>
+    );
+  }
+
+  if (initError) {
+    return (
+      <View style={styles.center}>
+        <Text style={styles.errorText}>{initError}</Text>
+        <Button title="Retry" onPress={initializeApp} />
+        <View style={styles.spacer} />
+        <Button title="Offline Mode" onPress={handleOfflineMode} />
+      </View>
+    );
+  }
 
   return (
     <>
@@ -60,6 +90,24 @@ const AppContent: React.FC = () => {
     </>
   );
 };
+
+const styles = StyleSheet.create({
+  center: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#1a1a1a',
+    padding: 20,
+  },
+  errorText: {
+    color: '#ffffff',
+    textAlign: 'center',
+    marginBottom: 16,
+  },
+  spacer: {
+    height: 12,
+  },
+});
 
 export default function App() {
   return (


### PR DESCRIPTION
## Summary
- show a user-visible screen when app initialization fails
- allow retry or entering offline mode if session creation is rejected

## Testing
- `npm test` (fails: SyntaxError: Cannot use import statement outside a module)

------
https://chatgpt.com/codex/tasks/task_e_68bf4a3097f4832aa70e43ab88c067f9