### PR TITLE
feat: add configurable API host

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,6 @@ PORT=3001
 # Comma-separated list of allowed origins (optional)
 ALLOWED_ORIGINS=http://localhost:3000
 
+# API base URL for the Expo frontend (required)
+EXPO_PUBLIC_API_URL=http://localhost:3001/api
+

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ PORT=3001
 
 #### Frontend (.env)
 ```
-REACT_APP_API_URL=http://localhost:3001/api
+EXPO_PUBLIC_API_URL=http://localhost:3001/api
 ```
 
 ## Development
@@ -80,6 +80,16 @@ REACT_APP_API_URL=http://localhost:3001/api
 
 - `./rebuild-dev.sh` - Completely rebuild and restart the development environment
 - `./rebuild-prod.sh` - Completely rebuild and restart the production environment
+
+## Deployment
+
+Ensure your `.env` file defines `EXPO_PUBLIC_API_URL` pointing to the backend API.
+
+```bash
+cp .env.example .env
+# Edit .env and set EXPO_PUBLIC_API_URL=https://your-domain.com/api
+./deploy.sh
+```
 
 ## API Documentation
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -18,6 +18,12 @@ if ! grep -q "OPENAI_API_KEY=" .env || grep -q "your_openai_api_key_here" .env; 
     exit 1
 fi
 
+# Check if EXPO_PUBLIC_API_URL is set
+if ! grep -q "EXPO_PUBLIC_API_URL=" .env; then
+    echo "❌ EXPO_PUBLIC_API_URL not configured in .env file."
+    exit 1
+fi
+
 # Build and start services
 echo "🔨 Building Docker images..."
 docker-compose build --no-cache

--- a/frontend/src/services/gameApi.ts
+++ b/frontend/src/services/gameApi.ts
@@ -1,8 +1,10 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
-import { 
-  NewGameRequest, 
-  NewGameResponse, 
-  TurnRequest, 
+import { Platform } from 'react-native';
+import Constants from 'expo-constants';
+import {
+  NewGameRequest,
+  NewGameResponse,
+  TurnRequest,
   TurnResponse,
   SaveGameRequest,
   SavedGamesResponse,
@@ -51,11 +53,21 @@ interface GenerateSpeechRequest {
   quality?: 'standard' | 'high';
 }
 
-// Get API URL from environment with better fallback handling
-const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL || 
-                    (process.env.NODE_ENV === 'production' ? 
-                     'https://your-production-url.com/api' : 
-                     'http://localhost:3001/api');
+// Determine API URL based on environment and platform
+const resolveApiBaseUrl = (): string => {
+  if (process.env.EXPO_PUBLIC_API_URL) {
+    return process.env.EXPO_PUBLIC_API_URL;
+  }
+
+  if (Platform.OS === 'web') {
+    return '/api';
+  }
+
+  const host = Constants.expoConfig?.hostUri?.split(':')[0];
+  return `http://${host ?? 'localhost'}:3001/api`;
+};
+
+const API_BASE_URL = resolveApiBaseUrl();
 
 // Add a health check function to verify API connectivity
 export const checkApiConnectivity = async (): Promise<boolean> => {


### PR DESCRIPTION
## Summary
- dynamically resolve API base URL based on platform or EXPO_PUBLIC_API_URL
- add EXPO_PUBLIC_API_URL to sample env and deployment docs
- ensure deploy script checks for EXPO_PUBLIC_API_URL

## Testing
- `npm test` (fails: Cannot use import statement outside a module in Expo packages)

------
https://chatgpt.com/codex/tasks/task_e_68bf4a1bd430832aac46ed7020f37aed