### PR TITLE
Add development orchestration script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "./launch-game.sh",
     "quick": "./quick-launch.sh",
-    "dev": "./launch-game.sh",
+    "dev": "bash scripts/start-dev.sh",
     "backend": "./launch-game.sh --backend-only",
     "frontend": "./launch-game.sh --frontend-only",
     "setup": "cd backend && npm install --legacy-peer-deps && cd ../frontend && npm install --legacy-peer-deps",

--- a/scripts/start-dev.sh
+++ b/scripts/start-dev.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env sh
+set -e
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+cleanup() {
+    [ -n "$BACKEND_PID" ] && kill "$BACKEND_PID" 2>/dev/null || true
+    [ -n "$FRONTEND_PID" ] && kill "$FRONTEND_PID" 2>/dev/null || true
+    docker compose -f "$ROOT_DIR/docker-compose.dev.yml" down >/dev/null 2>&1 || true
+}
+
+trap 'cleanup; exit 0' INT TERM
+
+cd "$ROOT_DIR"
+docker compose -f docker-compose.dev.yml up -d mongodb redis
+
+(
+    cd "$ROOT_DIR/backend" && npm run dev
+) &
+BACKEND_PID=$!
+
+(
+    cd "$ROOT_DIR/frontend" && npx expo start --port 8082
+) &
+FRONTEND_PID=$!
+
+wait "$BACKEND_PID" "$FRONTEND_PID"
+cleanup


### PR DESCRIPTION
## Summary
- Add start-dev script to spin up MongoDB, Redis, backend and frontend in parallel
- Link new script to package.json `dev` command

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bf5770ab40832ab104d2dfebed6ee5