### PR TITLE
fix: ensure prompt fallback world description meets minimum length

### DIFF
--- a/backend/src/services/__tests__/openAIService.fallback.test.ts
+++ b/backend/src/services/__tests__/openAIService.fallback.test.ts
@@ -1,0 +1,14 @@
+import { openAIService } from '../openAIService';
+import { CustomAdventureValidator } from '../customAdventureValidator';
+import { VALIDATION_RULES } from '../../../../shared/constants';
+
+describe('OpenAI Service - Fallback Adventure Generation', () => {
+  it('provides a fallback adventure that passes validation when API key is missing', async () => {
+    const adventure = await openAIService.generateAdventureFromPrompt('test prompt');
+    const validation = CustomAdventureValidator.validateAdventureDetails(adventure);
+    expect(validation.isValid).toBe(true);
+    expect(adventure.setting.world_description.length).toBeGreaterThanOrEqual(
+      VALIDATION_RULES.MIN_WORLD_DESCRIPTION_LENGTH
+    );
+  });
+});

--- a/backend/src/services/openAIService.ts
+++ b/backend/src/services/openAIService.ts
@@ -274,7 +274,8 @@ class OpenAIService {
       title: 'Default Adventure',
       description: 'A default adventure generated due to an error',
       setting: {
-        world_description: 'A mysterious realm',
+        world_description:
+          'A mysterious realm filled with ancient ruins and untold magical secrets, challenging every brave explorer who enters',
         time_period: { type: 'predefined', value: 'medieval' },
         environment: 'Unknown territory'
       },


### PR DESCRIPTION
## Summary
- expand fallback world description in OpenAI service so generated adventures meet minimum length requirements
- add test covering fallback adventure validation

## Testing
- `npm test` *(fails: express_validator_1.body(...).optional is not a function)*
- `npx ts-node -e "const {openAIService} = require('./src/services/openAIService'); (async () => { const adv = await openAIService.generateAdventureFromPrompt('prompt'); console.log('length', adv.setting.world_description.length); })();"`


------
https://chatgpt.com/codex/tasks/task_e_68bf742b106c832aa953dd47b1786358