### PR TITLE
Handle unsupported JSON response format for OpenAI models

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,6 +4,9 @@ REDIS_URL=redis://localhost:6379
 
 # OpenAI
 OPENAI_API_KEY=your_openai_api_key_here
+# Enable JSON response formatting for supported OpenAI models
+# Set to 'true' only when using a model that supports the json_object response_format
+OPENAI_JSON_RESPONSE=false
 
 # JWT
 JWT_SECRET=your_super_secret_jwt_key_here

--- a/backend/src/services/openAIService.ts
+++ b/backend/src/services/openAIService.ts
@@ -309,13 +309,19 @@ class OpenAIService {
         { role: 'user', content: userPrompt }
       ];
 
-      const response = await this.openai.chat.completions.create({
+      const requestOptions: any = {
         model: 'gpt-4',
         messages: messages as any,
         temperature: 0.8,
         max_tokens: 1000,
-        response_format: { type: 'json_object' }
-      });
+      };
+
+      // Only include the JSON response format parameter for models that support it
+      if (process.env.OPENAI_JSON_RESPONSE === 'true') {
+        requestOptions.response_format = { type: 'json_object' };
+      }
+
+      const response = await this.openai.chat.completions.create(requestOptions);
 
       const aiResponse = response.choices[0]?.message?.content;
       if (!aiResponse) {


### PR DESCRIPTION
## Summary
- Guard OpenAI chat completion requests so `response_format` is only sent when explicitly enabled
- Add `OPENAI_JSON_RESPONSE` flag to backend `.env.example`

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf774c81b0832aa159c7b2970a053c