### PR TITLE
refactor: replace Math.random with crypto.randomUUID

### DIFF
--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
+import { randomUUID } from 'crypto';
 import { CustomError } from './errorHandler';
 import { HTTP_STATUS, ERROR_MESSAGES } from '../../../shared/constants';
 import { logger } from '../utils/logger';
@@ -63,7 +64,7 @@ export const authMiddleware = async (
 };
 
 export const generateAnonymousToken = (): string => {
-  return 'anon_' + Date.now().toString(36) + Math.random().toString(36).substr(2);
+  return 'anon_' + Date.now().toString(36) + randomUUID().replace(/-/g, '');
 };
 
 export const generateJWTToken = (userId: string, isAnonymous: boolean = false): string => {

--- a/frontend/src/store/offlineSlice.ts
+++ b/frontend/src/store/offlineSlice.ts
@@ -69,7 +69,7 @@ const offlineSlice = createSlice({
     queueAction: (state, action: PayloadAction<Omit<PendingAction, 'id' | 'timestamp' | 'retryCount'>>) => {
       const newAction: PendingAction = {
         ...action.payload,
-        id: `action_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
+        id: `action_${Date.now()}_${crypto.randomUUID().replace(/-/g, '')}`,
         timestamp: Date.now(),
         retryCount: 0,
       };

--- a/shared/utils.ts
+++ b/shared/utils.ts
@@ -60,11 +60,11 @@ export function sanitizeInput(input: string): string {
 }
 
 export function generateSessionId(): string {
-  return 'session_' + Date.now().toString(36) + Math.random().toString(36).substr(2);
+  return 'session_' + Date.now().toString(36) + crypto.randomUUID().replace(/-/g, '');
 }
 
 export function generateTurnId(): string {
-  return 'turn_' + Date.now().toString(36) + Math.random().toString(36).substr(2);
+  return 'turn_' + Date.now().toString(36) + crypto.randomUUID().replace(/-/g, '');
 }
 
 export function formatTimestamp(date: Date): string {


### PR DESCRIPTION
## Summary
- replace Math.random-based IDs with crypto.randomUUID for anonymous token generation
- use crypto.randomUUID in shared utils for session and turn IDs
- generate offline action IDs with crypto.randomUUID

## Testing
- `cd backend && npm test` *(fails: jest not found)*
- `cd frontend && npm test` *(fails: jest not found)*
- `cd shared && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bff355d344832abff1f47970e6cdde