### PR TITLE
fix: enforce moderation failure handling

### DIFF
--- a/backend/src/services/openAIService.ts
+++ b/backend/src/services/openAIService.ts
@@ -629,7 +629,8 @@ class OpenAIService {
 
   async moderateContent(text: string): Promise<boolean> {
     if (!this.openai.apiKey) {
-      return true; // Allow content if moderation is unavailable
+      logger.error('OpenAI API key not configured for moderation');
+      return false;
     }
 
     try {
@@ -642,7 +643,7 @@ class OpenAIService {
 
     } catch (error) {
       logger.error('Content moderation failed:', error);
-      return true; // Allow content if moderation fails
+      throw new CustomError(ERROR_MESSAGES.AI_SERVICE_ERROR, HTTP_STATUS.INTERNAL_SERVER_ERROR);
     }
   }
 


### PR DESCRIPTION
## Summary
- ensure content moderation returns false if OpenAI API key missing
- throw CustomError when moderation request fails

## Testing
- `npm test` (fails: jest not found after npm install failure)


------
https://chatgpt.com/codex/tasks/task_e_68bff35cf6a0832a9fdd4a6213a6def5