### PR TITLE
Fix cache enforcement to avoid undefined keys

### DIFF
--- a/backend/src/services/imageEnhancementService.ts
+++ b/backend/src/services/imageEnhancementService.ts
@@ -134,7 +134,11 @@ export class ImageEnhancementService {
   private enforceCacheLimit(): void {
     while (this.imageCache.size > this.MAX_CACHE_SIZE) {
       const oldestKey = this.imageCache.keys().next().value;
-      this.imageCache.delete(oldestKey);
+      if (oldestKey !== undefined) {
+        this.imageCache.delete(oldestKey);
+      } else {
+        break;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Prevent `enforceCacheLimit` from passing undefined keys to `Map.delete`

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run build` *(fails: Cannot find module 'mongoose', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bffc7cbe8c832a9577d6d3c1099bd0